### PR TITLE
Pass Billing Address for Apple Pay Transactions

### DIFF
--- a/packages/lib/src/components/ApplePay/ApplePay.test.ts
+++ b/packages/lib/src/components/ApplePay/ApplePay.test.ts
@@ -1,5 +1,6 @@
 import ApplePay from '.';
 import defaultProps from './defaultProps';
+import { formatBillingAddress } from './utils';
 
 (global as any).ApplePaySession = {
     supportsVersion: jest.fn(() => true)
@@ -34,6 +35,59 @@ describe('ApplePay', () => {
         test('always returns a type', () => {
             const applepay = new ApplePay(defaultProps);
             expect(applepay.data).toMatchObject({ paymentMethod: { type: 'applepay' } });
+        });
+    });
+
+    describe('format billing contact as billing address', () => {
+        test('Moves house number from address line 1 into house number and unit to end of street', () => {
+            const billingContact = {
+                addressLines: ['1 Infinite Loop', 'Unit 100'],
+                locality: 'Cupertino',
+                administrativeArea: 'CA',
+                postalCode: '95014',
+                countryCode: 'US',
+                country: 'United States',
+                givenName: 'John',
+                familyName: 'Appleseed',
+                phoneticFamilyName: '',
+                phoneticGivenName: '',
+                subAdministrativeArea: '',
+                subLocality: ''
+            };
+
+            const billingAddress = formatBillingAddress(billingContact);
+
+            expect(billingAddress.houseNumberOrName).toEqual('1');
+            expect(billingAddress.street).toEqual('Infinite Loop Unit 100');
+            expect(billingAddress.city).toEqual('Cupertino');
+            expect(billingAddress.postalCode).toEqual('95014');
+            expect(billingAddress.country).toEqual('US');
+            expect(billingAddress.stateOrProvince).toEqual('CA');
+        });
+        test('When only postal code provided, returns billing address with only postal code', () => {
+            const billingContact = {
+                addressLines: [],
+                locality: '',
+                administrativeArea: '',
+                postalCode: '95014',
+                countryCode: '',
+                country: '',
+                givenName: '',
+                familyName: '',
+                phoneticFamilyName: '',
+                phoneticGivenName: '',
+                subAdministrativeArea: '',
+                subLocality: ''
+            };
+
+            const billingAddress = formatBillingAddress(billingContact);
+
+            expect(billingAddress.houseNumberOrName).toEqual('');
+            expect(billingAddress.street).toEqual('');
+            expect(billingAddress.city).toEqual('');
+            expect(billingAddress.postalCode).toEqual('95014');
+            expect(billingAddress.country).toEqual('');
+            expect(billingAddress.stateOrProvince).toEqual('');
         });
     });
 });

--- a/packages/lib/src/components/ApplePay/ApplePay.test.ts
+++ b/packages/lib/src/components/ApplePay/ApplePay.test.ts
@@ -39,7 +39,7 @@ describe('ApplePay', () => {
     });
 
     describe('format billing contact as billing address', () => {
-        test('Moves house number from address line 1 into house number and unit to end of street', () => {
+        test('moves house number from address line 1 into house number and unit to end of street', () => {
             const billingContact = {
                 addressLines: ['1 Infinite Loop', 'Unit 100'],
                 locality: 'Cupertino',
@@ -64,7 +64,7 @@ describe('ApplePay', () => {
             expect(billingAddress.country).toEqual('US');
             expect(billingAddress.stateOrProvince).toEqual('CA');
         });
-        test('When only postal code provided, returns billing address with only postal code', () => {
+        test('when only postal code provided, returns billing address with only postal code', () => {
             const billingContact = {
                 addressLines: [],
                 locality: '',

--- a/packages/lib/src/components/ApplePay/utils.ts
+++ b/packages/lib/src/components/ApplePay/utils.ts
@@ -41,7 +41,6 @@ export function mapBrands(brands) {
  * ApplePay formats address into two lines (US format). First line includes house number and street name.
  * Second line includes unit/suite/apartment number if applicable.
  * This function formats it into Adyen's Address format (house number separate from street).
- * @param billingContact
  */
 export function formatBillingAddress(billingContact: ApplePayJS.ApplePayPaymentContact) {
     let street = '';

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -1,16 +1,14 @@
 import { h } from 'preact';
-import BaseElement from './BaseElement';
-import { PaymentAction } from '../types';
-import { PaymentResponse } from './types';
-import PayButton from './internal/PayButton';
-import { IUIElement, PayButtonFunctionProps, RawPaymentResponse, UIElementProps } from './types';
-import { getSanitizedResponse, resolveFinalResult } from './utils';
-import AdyenCheckoutError from '../core/Errors/AdyenCheckoutError';
-import { UIElementStatus } from './types';
-import { hasOwnProperty } from '../utils/hasOwnProperty';
-import DropinElement from './Dropin';
-import { CoreOptions } from '../core/types';
 import Core from '../core';
+import AdyenCheckoutError from '../core/Errors/AdyenCheckoutError';
+import { CoreOptions } from '../core/types';
+import { PaymentAction } from '../types';
+import { hasOwnProperty } from '../utils/hasOwnProperty';
+import BaseElement from './BaseElement';
+import DropinElement from './Dropin';
+import PayButton from './internal/PayButton';
+import { IUIElement, PayButtonFunctionProps, PaymentResponse, RawPaymentResponse, UIElementProps, UIElementStatus } from './types';
+import { getSanitizedResponse, resolveFinalResult } from './utils';
 
 export class UIElement<P extends UIElementProps = any> extends BaseElement<P> implements IUIElement {
     protected componentRef: any;

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -1,14 +1,16 @@
 import { h } from 'preact';
-import Core from '../core';
-import AdyenCheckoutError from '../core/Errors/AdyenCheckoutError';
-import { CoreOptions } from '../core/types';
-import { PaymentAction } from '../types';
-import { hasOwnProperty } from '../utils/hasOwnProperty';
 import BaseElement from './BaseElement';
-import DropinElement from './Dropin';
+import { PaymentAction } from '../types';
+import { PaymentResponse } from './types';
 import PayButton from './internal/PayButton';
-import { IUIElement, PayButtonFunctionProps, PaymentResponse, RawPaymentResponse, UIElementProps, UIElementStatus } from './types';
+import { IUIElement, PayButtonFunctionProps, RawPaymentResponse, UIElementProps } from './types';
 import { getSanitizedResponse, resolveFinalResult } from './utils';
+import AdyenCheckoutError from '../core/Errors/AdyenCheckoutError';
+import { UIElementStatus } from './types';
+import { hasOwnProperty } from '../utils/hasOwnProperty';
+import DropinElement from './Dropin';
+import { CoreOptions } from '../core/types';
+import Core from '../core';
 
 export class UIElement<P extends UIElementProps = any> extends BaseElement<P> implements IUIElement {
     protected componentRef: any;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

This pull request introduces a crucial fix for handling Apple Pay payments in the Adyen library. 

The motivation behind this change is to enable the submission of billing contact information when it's requested during an Apple Pay transaction. Previously, the library did not submit this information along with the payment requests even if it was requested from Apple Pay `requiredBillingContactFields: ['postalAddress']`.

This PR addresses the issue where the library was incapable of handling Address Verification with Apple Pay due to the absence of billing contact information in the payment requests. This limitation hindered the full utilization of Apple Pay's capabilities, risk, and higher interchange costs due to missing AVS validation.

## Tested scenarios
Conversion of billingContact Apple Pay object to BillingAddress Adyen backend understands. 


